### PR TITLE
feat(integration): fix link colours around dealer portal

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -324,8 +324,7 @@ body, html {
                         }
 
 a:link, a:visited, a:hover, a:active { 
-    text-decoration: none; 
-    color: inherit;
+    text-decoration: none;
 }
 
 .dashIcon, .dashboardLogo {


### PR DESCRIPTION
This line is breaking button colours around the outside of the embedded dealer portal.

Before:

<img width="496" alt="image" src="https://user-images.githubusercontent.com/1038062/236149758-6c291097-2b01-40aa-974f-4209d8baf99c.png">

After:

<img width="489" alt="image" src="https://user-images.githubusercontent.com/1038062/236149833-17b14ff3-2c9d-4527-850d-733e9ace262d.png">
